### PR TITLE
Extract purity from attributes earlier in plotNB

### DIFF
--- a/R/nbImport.R
+++ b/R/nbImport.R
@@ -91,6 +91,8 @@ plotNB <- function(nb = NULL, ref_build = "hg19", min.cn = 2, max.cn = 4, samp.n
     pdf(output.file, width = 7, height = 9)
   }
 
+  purity = attr(nb, "purity")
+
   segs <- attr(nb, "cnv")
   segs <- segs[order(chrom, start)]
   colnames(segs)[1:3] <- c("Chromosome", "Start_Position", "End_Position")
@@ -136,8 +138,8 @@ plotNB <- function(nb = NULL, ref_build = "hg19", min.cn = 2, max.cn = 4, samp.n
         title(main = paste0("CN:", as.numeric(ploidy), " (", as.numeric(ploidy) - as.numeric(B), ":", as.numeric(B), ")"), cex.main = 1.2)
         mtext(text = "No. of SNVs", side = 2, line = 2.5, cex = 0.7)
         mtext(text = "VAF", side = 1, line = 1.8, cex = 0.7)
-        if(!is.null(attr(nb, "purity")) & !is.null(attr(nb, "ploidy"))){
-          abline(v = .expectedClVAF(CN = as.numeric(names(nb)[cn]), purity = attr(nb, "purity")), lty = 2)
+        if(!is.null(purity)){
+          abline(v = .expectedClVAF(CN = as.numeric(names(nb)[cn]), purity = purity), lty = 2)
         }
       }
     }

--- a/man/plotNB.Rd
+++ b/man/plotNB.Rd
@@ -10,8 +10,6 @@ plotNB(
   min.cn = 2,
   max.cn = 4,
   samp.name = NULL,
-  purity = NULL,
-  ploidy = NULL,
   output.file = NULL
 )
 }
@@ -25,10 +23,6 @@ plotNB(
 \item{max.cn}{maximum copy number to be included in the plotting. Defaults to 4.}
 
 \item{samp.name}{Sample name. Optional. Default NULL}
-
-\item{purity}{optional. If \code{purity} and \code{ploidy} are both given, expected positions of clonal peaks are shown.}
-
-\item{ploidy}{optional. If \code{purity} and \code{ploidy} are both given, expected positions of clonal peaks are shown.}
 
 \item{output.file}{optional, will save the plot.}
 }


### PR DESCRIPTION
purity must be extracted from the attributes before running `split`.