### PR TITLE
fix #50

### DIFF
--- a/R/nbImport.R
+++ b/R/nbImport.R
@@ -50,8 +50,8 @@ nbImport <- function(cnv = NULL, snv = NULL, purity = NULL, ploidy = NULL){
   colnames(sv)[which(colnames(sv) == "start")] <- "cn_start"
   colnames(sv)[which(colnames(sv) == "end")] <- "cn_end"
   attr(sv, "cnv") <- cnv
-  attr(sv, "purity") <- purity
-  attr(sv, "ploidy") <- ploidy
+  attr(sv, "purity") <- as.numeric(purity)
+  attr(sv, "ploidy") <- as.numeric(ploidy)
   sv
 }
 


### PR DESCRIPTION
After the latest changes, the Error: Error in x * purity : non-numeric argument to binary operator occurs. This can be solved by changing purity and ploidy in NBImport from character to numeric (line 53 and 54). 

