### PR TITLE
fix #52: plotMutational densities ylim and xlim

### DIFF
--- a/R/plotMutationDensities.R
+++ b/R/plotMutationDensities.R
@@ -78,13 +78,14 @@ plotMutationDensities <- function(mrcaObj = NULL, samp.name = NULL, min.seg.size
                               (variable == "density_B_mean" & B > 1 & A != B), value],
                     breaks = bins, plot = FALSE)
   temp_hist_y <- max(temp_hist$counts, na.rm = TRUE)
+  temp_hist_x <- max(temp_hist$breaks, na.rm = TRUE)
 
   if(nrow(to.plot[(variable == "density_A_mean" & A > 1) |
                   (variable == "density_B_mean" & B > 1 & A != B),]) > 0){
     par(mar = c(3, 4, 3, 1))
     hist(to.plot[(variable == "density_A_mean" & A > 1) |
                    (variable == "density_B_mean" & B > 1 & A != B),value],
-         xlim = c(0, max(c(to.plot[,value], max(temp_d$x, na.rm = TRUE)))),
+         xlim = c(0, max(c(temp_hist_x, max(temp_d$x, na.rm = TRUE)))),
          ylim = c(0, max(c(temp_hist_y, max(temp_d$y, na.rm = TRUE)))),
          breaks = bins, col = fill.multi, border = l.col, main = NA,
          xlab = NA, ylab = NA)


### PR DESCRIPTION
The dotted density graph (show.den == TRUE) at "Multi-copy SNV densities"-graph in plot Mutational densities is often not displayed completely. Therefor ylim and xlim need to be defined dynamically. 