### PR TITLE
fix #44 read.delim to fread and write.table to fwrite

### DIFF
--- a/R/LACHESIS.R
+++ b/R/LACHESIS.R
@@ -78,7 +78,7 @@ LACHESIS <- function(input.files = NULL, ids = NULL, vcf.tumor.ids = NULL, cnv.f
                      ref_build = "hg19", ...){
 
 
-  ID <- cnv.file <- snv.file <- write.table <- NULL
+  ID <- cnv.file <- snv.file <- fwrite <- NULL
 
   if(is.null(input.files) & is.null(cnv.files)){
     stop("Missing input file!")
@@ -221,9 +221,10 @@ LACHESIS <- function(input.files = NULL, ids = NULL, vcf.tumor.ids = NULL, cnv.f
 
       # output the result for this sample
       if(!is.null(output.dir)){
-        write.table(unlist(attributes(mrca)[c("purity", "ploidy", "MRCA_time_mean", "MRCA_time_lower", "MRCA_time_upper", "ECA_time_mean", "ECA_time_lower", "ECA_time_upper")]),
-              file = paste(output.dir, x$ID, paste("MRCA_densities_", x$ID, ".txt", sep=""), sep="/"), quote = F, col.names = F, sep="\t")
-        write.table(mrca, file = paste(output.dir, x$ID, paste("SNV_timing_per_segment_", x$ID, ".txt", sep=""), sep="/"), row.names = F, quote=F, sep="\t")
+        mrca.densities <- transpose(data.table(unlist(attributes(mrca)[c("purity", "ploidy", "MRCA_time_mean", "MRCA_time_lower", "MRCA_time_upper", "ECA_time_mean", "ECA_time_lower", "ECA_time_upper")]))
+        )
+        data.table::fwrite(mrca.densities, file = file.path(output.dir, x$ID, paste0("MRCA_densities_", x$ID, ".txt")), quote = F, col.names = F, sep="\t")
+        data.table::fwrite(mrca, file = file.path(output.dir, x$ID, paste0("SNV_timing_per_segment_", x$ID, ".txt")), row.names = FALSE, quote = FALSE, sep = "\t")
       }
 
       if(!is.null(output.dir)){
@@ -263,7 +264,6 @@ LACHESIS <- function(input.files = NULL, ids = NULL, vcf.tumor.ids = NULL, cnv.f
         warning("No SNV file provided for sample ", ids[i], "; sample will be excluded")
         next
       }
-
 
       cnv <- readCNV(cn.info = cnv.files[i], chr.col = cnv.chr.col[i], start.col = cnv.start.col[i],
                      end.col = cnv.end.col[i], A.col = cnv.A.col[i], B.col = cnv.B.col[i],
@@ -316,9 +316,10 @@ LACHESIS <- function(input.files = NULL, ids = NULL, vcf.tumor.ids = NULL, cnv.f
 
         # output the result for this sample
         if(!is.null(output.dir)){
-          write(unlist(attributes(mrca)[c("purity", "ploidy", "MRCA_time_mean", "MRCA_time_lower", "MRCA_time_upper", "ECA_time_mean", "ECA_time_lower", "ECA_time_upper")]),
-                file = paste(output.dir, ids[i], paste("MRCA_densities_", ids[i], ".txt", sep=""), sep="/"))
-          write.table(mrca, file = paste(output.dir, ids[i], paste("SNV_timing_per_segment_", ids[i], ".txt", sep=""), sep="/"))
+          mrca.densities <- transpose(data.table(unlist(attributes(mrca)[c("purity", "ploidy", "MRCA_time_mean", "MRCA_time_lower", "MRCA_time_upper", "ECA_time_mean", "ECA_time_lower", "ECA_time_upper")]))
+          )
+          data.table::fwrite(mrca.densities, file = file.path(output.dir, ids[i], paste0("MRCA_densities_", ids[i], ".txt")), quote = F, col.names = F, sep="\t")
+          data.table::fwrite(mrca, file = file.path(output.dir, ids[i], paste0("SNV_timing_per_segment_", ids[i], ".txt")), row.names = FALSE, quote = FALSE, sep = "\t")
         }
 
         if(!is.null(output.dir)){

--- a/R/readCNV.R
+++ b/R/readCNV.R
@@ -21,7 +21,7 @@
 #' cn_data = readCNV(ascat_cn)
 #' @return A standardized data frame with copy number information per segment.
 #' readCNV()
-#' @importFrom utils read.delim write.table
+#' @import data.table
 #' @importFrom graphics plot.new
 #' @importFrom grDevices dev.off pdf
 #' @importFrom stats cor density end plot.ecdf start
@@ -38,7 +38,15 @@ readCNV <- function(cn.info = NULL, chr.col = NULL, start.col = NULL, end.col = 
   estimate.alleles <- FALSE # will be set to TRUE if allele info is not provided, see below
 
   ## Read cn.info and assume column index if not provided
-  cn.info <- .format_cnv_data(cn.info = cn.info, chr.col = chr.col, start.col = start.col, end.col = end.col, A.col = A.col, B.col = B.col, tcn.col = tcn.col)
+  format.cnv <- .format_cnv_data(cn.info = cn.info, chr.col = chr.col, start.col = start.col, end.col = end.col, A.col = A.col, B.col = B.col, tcn.col = tcn.col)
+
+  cn.info <- format.cnv$cn.info
+  chr.col <- format.cnv$chr.col
+  start.col <- format.cnv$start.col
+  end.col <- format.cnv$end.col
+  A.col <- format.cnv$A.col
+  B.col <- format.cnv$B.col
+  tcn.col <- format.cnv$tcn.col
 
   message("********** Read in ", nrow(cn.info), " segments with copy number information on ", length(unique(cn.info[[chr.col]])), " chromosomes.")
 
@@ -144,7 +152,7 @@ readCNV <- function(cn.info = NULL, chr.col = NULL, start.col = NULL, end.col = 
   return(cn.info)
 }
 
-.format_cnv_data <- function(cn.info = cn.info, chr.col = NULL, start.col = NULL, end.col = NULL, A.col = NULL, B.col = NULL, tcn.col = NULL) {
+.format_cnv_data <- function(cn.info = NULL, chr.col = NULL, start.col = NULL, end.col = NULL, A.col = NULL, B.col = NULL, tcn.col = NULL){
   cn.info <- data.table::fread(file = cn.info, sep = "\t", header = TRUE)
 
 
@@ -279,7 +287,7 @@ readCNV <- function(cn.info = NULL, chr.col = NULL, start.col = NULL, end.col = 
     stop("Error: end position must be numeric.")
   }
 
-  return(cn.info)
+  return(list(cn.info = cn.info, chr.col = chr.col, start.col = start.col, end.col = end.col, A.col = A.col, B.col = B.col, tcn.col = tcn.col))
 }
 
 .estimate_alleles <- function(cn.info, tcn.col){


### PR DESCRIPTION
I changed write.table to fwrite in LACHESIS wrapper function and read.delim to fread in readCNV to improve the speed as discussed in our meeting. In addition, Anand suggested to create a function (.format_cnv_data) that reads cnv.info and assumes the column name/index if not provided for a clearer structure. Are you fine with these changes @VerenaK90?
I ran it on some samples, but maybe you could also test it to be save.  