### PR TITLE
docs: fix vignette output file descriptions

### DIFF
--- a/vignettes/vignette_LACHESIS.Rmd
+++ b/vignettes/vignette_LACHESIS.Rmd
@@ -74,9 +74,9 @@ LACHESIS utilizes whole genome sequencing data to determine the mutational timin
 
 #### Datatables (.txt)
 
-* **SNV_timing_per_segment_ID.txt:** purity, ploidy, and the estimated mean, lower, and upper bounds for the timing of the tumor's MRCA and ECA (if detected)
+* **SNV_timing_per_segment_ID.txt:** per-segment mutation time, differentiated by minor and major copy number (A and B). For more details go to [Estimating Mutation Densities at ECA/MRCA (MRCA)](#estimating-mutation-densities-at-ecamrca-mrca)
 * **SNV_timing_per_SNV_ID.txt:** SNV context, clonality status and association with ECA/ MRCA.
-* **MRCA_densities_ID.txt:** per-segment mutation time, differentiated by minor and major copy number (A and B) For more details go to [Estimating Mutation Densities at ECA/MRCA (MRCA)](#estimating-mutation-densities-at-ecamrca-mrca)
+* **MRCA_densities_ID.txt:** purity, ploidy, and the estimated mean, lower, and upper bounds for the timing of the tumor's MRCA and ECA (if detected)
 
 #### Graphs (.pdf)
 
@@ -484,9 +484,9 @@ MRCA(normObj = NULL, min.seg.size = 10^7, fp.mean = 0, fp.sd = 0, excl.chr = NUL
 
 #### Output
 
-* **SNV_timing_per_segment_ID.txt:** purity, ploidy, and the estimated mean, lower, and upper bounds for the timing of the tumor's MRCA and ECA (if detected).
+* **MRCA_densities_ID.txt:** purity, ploidy, and the estimated mean, lower, and upper bounds for the timing of the tumor's MRCA and ECA (if detected).
 
-* **MRCA_densities_ID.txt:** per-segment mutation time, differentiated by minor and major copy number (A and B). For each segment,
+* **SNV_timing_per_segment_ID.txt:** per-segment mutation time, differentiated by minor and major copy number (A and B). For each segment,
 ```{r MRCA_output, echo=FALSE}
 library(knitr)
 


### PR DESCRIPTION
## Summary
- swap the LACHESIS vignette descriptions for `SNV_timing_per_segment_ID.txt` and `MRCA_densities_ID.txt`
- keep the per-segment column table attached to `SNV_timing_per_segment_ID.txt`

## Validation
- `rg -n "SNV_timing_per_segment_ID\.txt|MRCA_densities_ID\.txt|03_MRCA_densities_|04_SNV_timing_per_segment_|mrca_colnames|fwrite\(mrca" vignettes/vignette_LACHESIS.Rmd R/LACHESIS.R -S`
- `git diff --check`

This addresses #130.